### PR TITLE
Modified Readme.md with updated Netatmo url and modified curl sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To be able to access your data, you need to have an Netatmo Application and gran
 
 #### Register an App
 
-Your can register a new app [here](https://dev.netatmo.com/dev/createapp). Afterwards you will get an APP_ID and an APP_SECRET which you will need to enter in the [config entries](#configuration).
+Your can register a new app [here](https://dev.netatmo.com/apps/createanapp). Afterwards you will get an APP_ID and an APP_SECRET which you will need to enter in the [config entries](#configuration).
 
 #### Grant Access to Your Data
 
@@ -40,7 +40,7 @@ To allow the app to access your data, you need to send a POST request to the aut
 One option is to use the command line tool [cURL](https://www.google.de/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&cad=rja&uact=8&ved=0ahUKEwjqgN789KnaAhUBalAKHR-NDLoQFgg2MAE&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FCURL&usg=AOvVaw27-lfQBHvLQPR2qsddIR6U). 
 
 ```
-curl --data "grant_type=password&client_id=YOUR_CLIENT_ID&client_secret=YOUR_CLIENT_SECRET&username=YOUR_NETATMO_USERNAME&password=YOUR_NETATMO_PASSWORD&scope=read_station" "https://api.netatmo.com/oauth2/token"
+curl -X POST -d "grant_type=password" -d "client_id=YOUR_CLIENT_ID" -d "client_secret=YOUR_CLIENT_SECRET" -d "username=YOUR_NETATMO_USERNAME" -d "password=YOUR_NETATMO_PASSWORD" -d "scope=read_station" "https://api.netatmo.com/oauth2/token"
 ```
 
 The POST request will return the following data:


### PR DESCRIPTION
I have updated the information regarding creating a Netatmo app so that it points to the correct url at Netatmo.
I have also modified the curl sample so that it works out-of-the box with only replacing the placeholders, the previous version gave an error when trying to generate the refresh token: {"error":"invalid_grant"}.