### PR TITLE
feat: display all Netatmo stations

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The following properties can be configured:
 |`showWiFi`|Control the appearance of the Wifi perception.|`true`|no|
 |`showTrend`|Control the appearance of the temperature and pressure trend.|`true`|no|
 |`showMeasurementIcon`|Control the appearance of the data entry icons (`bubbles` design only).|`true`|no|
-|`showStationName`|Control the appearance of the station name next to the module name.|`false`|no|
+|`showStationName`|Control the appearance of the station name next to the module name.|`true`|no|
 |`fontClassModuleName`|Control font size class of the module name.|`xsmall`|no|
 |`fontClassPrimary`|Control font size class of the primary value (`bubbles` design only).|`large`|no|
 |`fontClassSecondary`|Control font size class of the secondary value (`bubbles` design only).|`xsmall`|no|

--- a/netatmo.js
+++ b/netatmo.js
@@ -21,6 +21,7 @@ Module.register('netatmo', {
     showTrend: true,
     showMeasurementIcon: true,
     showMeasurementLabel: true,
+    showStationName: true,
     apiBase: 'api.netatmo.com',
     authEndpoint: '/oauth2/token',
     dataEndpoint: '/api/getstationsdata',
@@ -31,7 +32,6 @@ Module.register('netatmo', {
     thresholdCO2Average: 800,
     thresholdCO2Bad: 1800,
     mockData: false,
-    showStationName: false,
   },
   notifications: {
     AUTH: 'NETATMO_AUTH',

--- a/netatmo.js
+++ b/netatmo.js
@@ -80,31 +80,33 @@ Module.register('netatmo', {
       self.sendSocketNotification(self.notifications.DATA, self.config)
     }, this.config.updateInterval * 60 * 1000 + this.config.initialDelay * 1000)
   },
-  updateModuleList: function (station) {
+  updateModuleList: function (stationList) {
     let moduleList = []
 
-    moduleList.push(this.getModule(station, station.home_name))
+    for (const station of stationList) {
+      moduleList.push(this.getModule(station, station.home_name))
 
-    station.modules.forEach(function (module) {
-      moduleList.push(this.getModule(module, station.home_name))
-    }.bind(this))
+      station.modules.forEach(function (module) {
+        moduleList.push(this.getModule(module, station.home_name))
+      }.bind(this))
 
-    if (station.reachable) { this.lastUpdate = station.dashboard_data.time_utc }
-    this.loaded = true
-    if (JSON.stringify(this.moduleList) === JSON.stringify(moduleList)) {
-      return
-    }
-    // reorder modules
-    if (this.config.moduleOrder && this.config.moduleOrder.length > 0) {
-      const reorderedModuleList = []
-      for (const moduleName of this.config.moduleOrder) {
-        for (const module of moduleList) {
-          if (module.name === moduleName) {
-            reorderedModuleList.push(module)
+      if (station.reachable) { this.lastUpdate = station.dashboard_data.time_utc }
+      this.loaded = true
+      if (JSON.stringify(this.moduleList) === JSON.stringify(moduleList)) {
+        return
+      }
+      // reorder modules
+      if (this.config.moduleOrder && this.config.moduleOrder.length > 0) {
+        const reorderedModuleList = []
+        for (const moduleName of this.config.moduleOrder) {
+          for (const module of moduleList) {
+            if (module.name === moduleName) {
+              reorderedModuleList.push(module)
+            }
           }
         }
+        moduleList = reorderedModuleList
       }
-      moduleList = reorderedModuleList
     }
     this.moduleList = moduleList
   },
@@ -395,8 +397,8 @@ Module.register('netatmo', {
         console.log(payload)
         if (payload.status === 'OK') {
           console.log('devices returned')
-          const station = payload.payloadReturn[0]
-          self.updateModuleList(station)
+          const stationList = payload.payloadReturn
+          self.updateModuleList(stationList)
           self.updateDom(self.config.animationSpeed)
         } else if (payload.status === 'INVALID_TOKEN') {
           // node_module has no valid token, reauthenticate

--- a/netatmo.js
+++ b/netatmo.js
@@ -91,22 +91,22 @@ Module.register('netatmo', {
       }.bind(this))
 
       if (station.reachable) { this.lastUpdate = station.dashboard_data.time_utc }
-      this.loaded = true
-      if (JSON.stringify(this.moduleList) === JSON.stringify(moduleList)) {
-        return
-      }
-      // reorder modules
-      if (this.config.moduleOrder && this.config.moduleOrder.length > 0) {
-        const reorderedModuleList = []
-        for (const moduleName of this.config.moduleOrder) {
-          for (const module of moduleList) {
-            if (module.name === moduleName) {
-              reorderedModuleList.push(module)
-            }
+    }
+    this.loaded = true
+    if (JSON.stringify(this.moduleList) === JSON.stringify(moduleList)) {
+      return
+    }
+    // reorder modules
+    if (this.config.moduleOrder && this.config.moduleOrder.length > 0) {
+      const reorderedModuleList = []
+      for (const moduleName of this.config.moduleOrder) {
+        for (const module of moduleList) {
+          if (module.name === moduleName) {
+            reorderedModuleList.push(module)
           }
         }
-        moduleList = reorderedModuleList
       }
+      moduleList = reorderedModuleList
     }
     this.moduleList = moduleList
   },

--- a/sample/sample.json
+++ b/sample/sample.json
@@ -37,6 +37,26 @@
     },
     "modules": [
       {
+        "type": "NAModule4",
+        "module_name": "Indoor",
+        "data_type": [
+          "Temperature",
+          "CO2",
+          "Humidity"
+        ],
+        "battery_percent": 50,
+        "reachable": true,
+        "rf_status": 50,
+        "battery_vp": 5040,
+        "dashboard_data": {
+          "Temperature": 12.7,
+          "CO2": 995,
+          "Humidity": 72,
+          "min_temp": 12.2,
+          "max_temp": 12.8
+        }
+      },
+      {
         "type": "NAModule1",
         "module_name": "Outdoor",
         "data_type": [
@@ -92,33 +112,13 @@
           "sum_rain_24": 0,
           "sum_rain_1": 0
         }
-      },
-      {
-        "type": "NAModule4",
-        "module_name": "Indoor",
-        "data_type": [
-          "Temperature",
-          "CO2",
-          "Humidity"
-        ],
-        "battery_percent": 50,
-        "reachable": true,
-        "rf_status": 50,
-        "battery_vp": 5040,
-        "dashboard_data": {
-          "Temperature": 12.7,
-          "CO2": 995,
-          "Humidity": 72,
-          "min_temp": 12.2,
-          "max_temp": 12.8
-        }
       }
     ]
   },
   {
     "station_name": "Altona (Wohnzimmer)",
     "type": "NAMain",
-    "module_name": "MAIN2",
+    "module_name": "Main",
     "wifi_status": 50,
     "reachable": false,
     "co2_calibrating": false,
@@ -139,11 +139,11 @@
         10
       ]
     },
-    "home_name": "Hamburg",
+    "home_name": "Altona",
     "modules": [
       {
         "type": "NAModule1",
-        "module_name": "OUTDOOR2",
+        "module_name": "Outdoor",
         "data_type": [
           "Temperature",
           "Humidity"


### PR DESCRIPTION
With with PR all station the user has access to are displayed. Also station name is printed now **by default**. 

- To disable station names use `showStationName: false`.
- To filter stations to display use `moduleOrder` to filter out the modules you don't want to be displayed.

fixes #81 #98